### PR TITLE
Narrow matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- [cithare-{delete,export}: Add name and mail to narrow down the matching]()
+
 ## [0.10.1]
 - [cithare-add: Add length as a trigger for automic password generation](https://github.com/EruEri/ocithare/pull/4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [Unreleased]
-- [cithare-{delete,export}: Add name and mail to narrow down the matching]()
+- [cithare-{delete,export}: Add name and mail to narrow down the matching](https://github.com/EruEri/ocithare/pull/6)
 
 ## [0.10.1]
 - [cithare-add: Add length as a trigger for automic password generation](https://github.com/EruEri/ocithare/pull/4)

--- a/lib/commandline/cadd.ml
+++ b/lib/commandline/cadd.ml
@@ -131,7 +131,7 @@ let validate t =
   ()
 
 let run t =
-  let { replace; website; username; mail; gen_password } = t in
+  let { replace = _; website; username; mail; gen_password } = t in
   let () = validate t in
   let password = getpassword gen_password in
   let password =
@@ -147,10 +147,10 @@ let run t =
   in
   let manager = Libcithare.Manager.decrypt master_password in
   let () = Libcithare.Manager.save_state master_password manager in
-  let new_password =
+  let _new_password =
     Libcithare.Manager.create_password website username mail password
   in
-  let status, manager =
+  (* let status, manager =
     Libcithare.Manager.replace_or_add ~replace new_password manager
   in
   let () = Libcithare.Manager.encrypt master_password manager in
@@ -160,7 +160,7 @@ let run t =
         print_endline "Password added"
     | CsChanged ->
         print_endline "Password replaced"
-  in
+  in *)
   ()
 
 let command = cmd run

--- a/lib/commandline/cadd.ml
+++ b/lib/commandline/cadd.ml
@@ -151,16 +151,16 @@ let run t =
     Libcithare.Manager.create_password website username mail password
   in
   (* let status, manager =
-    Libcithare.Manager.replace_or_add ~replace new_password manager
-  in
-  let () = Libcithare.Manager.encrypt master_password manager in
-  let () =
-    match status with
-    | CsAdded ->
-        print_endline "Password added"
-    | CsChanged ->
-        print_endline "Password replaced"
-  in *)
+       Libcithare.Manager.replace_or_add ~replace new_password manager
+     in
+     let () = Libcithare.Manager.encrypt master_password manager in
+     let () =
+       match status with
+       | CsAdded ->
+           print_endline "Password added"
+       | CsChanged ->
+           print_endline "Password replaced"
+     in *)
   ()
 
 let command = cmd run

--- a/lib/commandline/cadd.ml
+++ b/lib/commandline/cadd.ml
@@ -131,7 +131,7 @@ let validate t =
   ()
 
 let run t =
-  let { replace = _; website; username; mail; gen_password } = t in
+  let { replace; website; username; mail; gen_password } = t in
   let () = validate t in
   let password = getpassword gen_password in
   let password =
@@ -147,20 +147,23 @@ let run t =
   in
   let manager = Libcithare.Manager.decrypt master_password in
   let () = Libcithare.Manager.save_state master_password manager in
-  let _new_password =
+  let new_password =
     Libcithare.Manager.create_password website username mail password
   in
-  (* let status, manager =
-       Libcithare.Manager.replace_or_add ~replace new_password manager
-     in
-     let () = Libcithare.Manager.encrypt master_password manager in
-     let () =
-       match status with
-       | CsAdded ->
-           print_endline "Password added"
-       | CsChanged ->
-           print_endline "Password replaced"
-     in *)
+  let status, manager =
+    Libcithare.Manager.insert ?mail ?username ~replace new_password manager
+  in
+  let () = Libcithare.Manager.encrypt master_password manager in
+  let () =
+    match status with
+    | Some CsAdded ->
+        print_endline "Password added"
+    | Some CsChanged ->
+        print_endline "Password replaced"
+    | None ->
+        Libcithare.Error.emit_already_existing_password
+          ~exit:Libcithare.Error.Code.cithare_warning_code ()
+  in
   ()
 
 let command = cmd run

--- a/lib/commandline/cexport/cexport.macos.ml
+++ b/lib/commandline/cexport/cexport.macos.ml
@@ -70,7 +70,13 @@ let fpaste ?mail ?username ~regex ~paste password =
 
       ()
 
-let term_cmd = CexportCommon.term_cmd validate fpaste
+let term_paste =
+  Arg.(
+    value & flag
+    & info [ "p"; "paste" ] ~doc:"Write the password into the pasteboard"
+  )
+
+let term_cmd = CexportCommon.term_cmd ~term_paste validate fpaste
 let doc = CexportCommon.doc
 let man = CexportCommon.man
 

--- a/lib/commandline/cexport/cexport.macos.ml
+++ b/lib/commandline/cexport/cexport.macos.ml
@@ -21,13 +21,6 @@ let name = CexportCommon.name
 
 type t = CexportCommon.export_t
 
-let term_website = CexportCommon.term_website
-let term_regex = CexportCommon.term_regex
-let term_paste = CexportCommon.term_paste
-let term_output = CexportCommon.term_output
-let term_name = CexportCommon.term_name
-let term_mail = CexportCommon.term_mail
-
 let validate t =
   let () = Libcithare.Manager.check_initialized () in
   let () =
@@ -41,7 +34,7 @@ let validate t =
   in
   ()
 
-let fpaste ~regex ~paste password =
+let fpaste ?mail ?username ~regex ~paste password =
   match paste with
   | false ->
       let () = print_endline password.Libcithare.Password.password in
@@ -59,6 +52,17 @@ let fpaste ~regex ~paste password =
                 ()
             in
             let () =
+              if Option.is_some mail then
+                Printf.printf "For : %s\n"
+                @@ Option.value ~default:String.empty password.mail
+            in
+            let () =
+              if Option.is_some username then
+                Printf.printf "For : %s\n"
+                @@ Option.value ~default:String.empty password.username
+            in
+
+            let () =
               Printf.printf "Password successfully written in pasteboard\n"
             in
             ()
@@ -67,12 +71,11 @@ let fpaste ~regex ~paste password =
       ()
 
 let term_cmd = CexportCommon.term_cmd validate fpaste
-
 let doc = CexportCommon.doc
 let man = [ `S Manpage.s_description; `P "Export passwords" ]
 
 let cmd () =
   let info = Cmd.info ~doc ~man name in
-  Cmd.v info term_cmd 
+  Cmd.v info term_cmd
 
 let command = cmd ()

--- a/lib/commandline/cexport/cexport.macos.ml
+++ b/lib/commandline/cexport/cexport.macos.ml
@@ -25,8 +25,8 @@ let term_website = CexportCommon.term_website
 let term_regex = CexportCommon.term_regex
 let term_paste = CexportCommon.term_paste
 let term_output = CexportCommon.term_output
-let term_display_time = CexportCommon.term_display_time
-let term_show_password = CexportCommon.term_show_password
+let term_name = CexportCommon.term_name
+let term_mail = CexportCommon.term_mail
 
 let validate t =
   let () = Libcithare.Manager.check_initialized () in
@@ -66,20 +66,13 @@ let fpaste ~regex ~paste password =
 
       ()
 
-let term_cmd () =
-  let combine website regex paste output =
-    let export =
-      new CexportCommon.export_t validate fpaste website regex paste output
-    in
-    export#run ()
-  in
-  Term.(const combine $ term_website $ term_regex $ term_paste $ term_output)
+let term_cmd = CexportCommon.term_cmd validate fpaste
 
 let doc = CexportCommon.doc
 let man = [ `S Manpage.s_description; `P "Export passwords" ]
 
 let cmd () =
   let info = Cmd.info ~doc ~man name in
-  Cmd.v info (term_cmd ())
+  Cmd.v info term_cmd 
 
 let command = cmd ()

--- a/lib/commandline/cexport/cexport.macos.ml
+++ b/lib/commandline/cexport/cexport.macos.ml
@@ -72,7 +72,7 @@ let fpaste ?mail ?username ~regex ~paste password =
 
 let term_cmd = CexportCommon.term_cmd validate fpaste
 let doc = CexportCommon.doc
-let man = [ `S Manpage.s_description; `P "Export passwords" ]
+let man = CexportCommon.man
 
 let cmd () =
   let info = Cmd.info ~doc ~man name in

--- a/lib/commandline/cexport/cexport.others.ml
+++ b/lib/commandline/cexport/cexport.others.ml
@@ -41,7 +41,7 @@ let fpaste ?mail ?username ~regex ~paste password =
             in
             let () =
               if Option.is_some mail then
-                Printf.printf "For mail: %s\n"
+                Printf.printf "For : %s\n"
                 @@ Option.value ~default:String.empty password.mail
             in
             let () =
@@ -68,7 +68,7 @@ let term_xclip =
            $(b,xclip(1))"
   )
 
-let term_cmd = CexportCommon.term_cmd validate fpaste
+let term_cmd = CexportCommon.term_cmd ~term_paste:term_xclip validate fpaste
 let doc = CexportCommon.doc
 let man = CexportCommon.man
 

--- a/lib/commandline/cexport/cexport.others.ml
+++ b/lib/commandline/cexport/cexport.others.ml
@@ -70,7 +70,7 @@ let term_xclip =
 
 let term_cmd = CexportCommon.term_cmd validate fpaste
 let doc = CexportCommon.doc
-let man = [ `S Manpage.s_description; `P "Export passwords" ]
+let man = CexportCommon.man
 
 let cmd () =
   let info = Cmd.info ~doc ~man name in

--- a/lib/commandline/cexport/cexport.others.ml
+++ b/lib/commandline/cexport/cexport.others.ml
@@ -21,7 +21,7 @@ let name = CexportCommon.name
 
 type t = CexportCommon.export_t
 
-let fpaste ~regex ~paste password =
+let fpaste ?mail ?username ~regex ~paste password =
   match paste with
   | false ->
       let () = print_endline password.Libcithare.Password.password in
@@ -38,6 +38,16 @@ let fpaste ~regex ~paste password =
             let () =
               if regex then
                 Printf.printf "For : %s\n" password.website
+            in
+            let () =
+              if Option.is_some mail then
+                Printf.printf "For mail: %s\n"
+                @@ Option.value ~default:String.empty password.mail
+            in
+            let () =
+              if Option.is_some username then
+                Printf.printf "For : %s\n"
+                @@ Option.value ~default:String.empty password.username
             in
             Printf.printf "Password successfully written in pasteboard\n"
         | _ ->
@@ -58,14 +68,7 @@ let term_xclip =
            $(b,xclip(1))"
   )
 
-let term_website = CexportCommon.term_website
-let term_regex = CexportCommon.term_regex
-let term_output = CexportCommon.term_output
-let term_name = CexportCommon.term_name
-let term_mail = CexportCommon.term_mail
-
 let term_cmd = CexportCommon.term_cmd validate fpaste
-
 let doc = CexportCommon.doc
 let man = [ `S Manpage.s_description; `P "Export passwords" ]
 

--- a/lib/commandline/cexport/cexport.others.ml
+++ b/lib/commandline/cexport/cexport.others.ml
@@ -61,23 +61,16 @@ let term_xclip =
 let term_website = CexportCommon.term_website
 let term_regex = CexportCommon.term_regex
 let term_output = CexportCommon.term_output
-let term_display_time = CexportCommon.term_display_time
-let term_show_password = CexportCommon.term_show_password
+let term_name = CexportCommon.term_name
+let term_mail = CexportCommon.term_mail
 
-let term_cmd () =
-  let combine website regex paste output =
-    let export =
-      new CexportCommon.export_t validate fpaste website regex paste output
-    in
-    export#run ()
-  in
-  Term.(const combine $ term_website $ term_regex $ term_xclip $ term_output)
+let term_cmd = CexportCommon.term_cmd validate fpaste
 
 let doc = CexportCommon.doc
 let man = [ `S Manpage.s_description; `P "Export passwords" ]
 
 let cmd () =
   let info = Cmd.info ~doc ~man name in
-  Cmd.v info (term_cmd ())
+  Cmd.v info term_cmd
 
 let command = cmd ()

--- a/lib/commandline/cexport/cexportCommon.ml
+++ b/lib/commandline/cexport/cexportCommon.ml
@@ -92,19 +92,13 @@ let term_website =
   Arg.(
     value
     & opt (some string) None
-    & info [ "w"; "website" ] ~docv:"WEBSITE" ~doc:"Specify the site"
+    & info [ "w"; "website" ] ~docv:"WEBSITE" ~doc:"Match the website"
   )
 
 let term_regex =
   Arg.(
     value & flag
-    & info [ "r"; "regex" ] ~doc:"Find the website by matching its name"
-  )
-
-let term_paste =
-  Arg.(
-    value & flag
-    & info [ "p"; "paste" ] ~doc:"Write the password into the pasteboard"
+    & info [ "r"; "regex" ] ~doc:"Treat each field as a regex string"
   )
 
 let term_output =
@@ -129,7 +123,7 @@ let term_mail =
     & info [ "m"; "mail" ] ~docv:"<MAIL>" ~doc:"Match the mail"
   )
 
-let term_cmd validate fpaste =
+let term_cmd ~term_paste validate fpaste =
   let combine mail username website regex paste output =
     let export =
       new export_t ?mail ?username validate fpaste website regex paste output

--- a/lib/commandline/cexport/cexportCommon.ml
+++ b/lib/commandline/cexport/cexportCommon.ml
@@ -76,8 +76,9 @@ class export_t validate fpaste website regex paste output =
               Str.regexp_string website
         in
         let manager = Libcithare.Manager.filter_rexp r manager in
+        let passwords = Libcithare.Manager.elements manager in
         let () =
-          match manager.passwords with
+          match passwords with
           | password :: [] ->
               fpaste ~regex ~paste password
           | [] ->
@@ -91,7 +92,7 @@ class export_t validate fpaste website regex paste output =
     method export : Libcithare.Manager.t -> string -> unit =
       fun manager path ->
         let () =
-          Yojson.Safe.to_file path @@ Libcithare.Manager.to_yojson manager
+          Libcithare.Manager.to_file path manager
         in
         ()
 

--- a/lib/commandline/cexport/cexportCommon.ml
+++ b/lib/commandline/cexport/cexportCommon.ml
@@ -61,6 +61,33 @@ class export_t ?mail ?username validate fpaste website regex paste output =
 let name = "export"
 let doc = "Export passwords"
 
+let man =
+  [
+    `S Manpage.s_description;
+    `P
+      "$(iname) retrieves passwords from $(mname), either the password for one \
+       entry or export all the passwords stored in a json formatted file";
+    `P "$(b,-m) and $(b,-n) options further narrows down the matching.";
+    `Noblank;
+    `P
+      "Narrow down the matching is mandatory if you try to retrieve a password \
+       from an entry where the website appears more than once.";
+    `P
+      "Regex option (ie. $(b,-r)) if provided, treats individually \
+       $(b,website), $(b,name) and $(b,mail) as a regex string";
+    `S Manpage.s_examples;
+    `I
+      ( "Export all the password into a file named passwords.json",
+        "$(iname) -o passwords.json"
+      );
+    `I ("Export password for the website sitea", "$(iname) -w sitea");
+    `I
+      ( "Export password for the a website matching $(b,sit) and a username \
+         matching $(b,user)",
+        "$(iname) -rw 'sit*' -u 'user*' "
+      );
+  ]
+
 let term_website =
   Arg.(
     value

--- a/lib/libcithare/error.ml
+++ b/lib/libcithare/error.ml
@@ -50,7 +50,10 @@ module Repr = struct
     | NoMatchingPassword ->
         "No matching password"
     | TooManyMatchingPasswords website ->
-        Printf.sprintf "Conflicting matching passwords:\n\t- %s"
+        Printf.sprintf
+          "Conflicting matching passwords:\n\
+           \t- %s\n\
+          \  Maybe try to narrow the search with -m and -n"
         @@ String.concat "\n\t- " website
     | CannotSaveState p ->
         Printf.sprintf "Can’t save state at %s" p

--- a/lib/libcithare/error.ml
+++ b/lib/libcithare/error.ml
@@ -15,6 +15,11 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
+module Code = struct
+  let cithare_error_code = 1
+  let cithare_warning_code = 2
+end
+
 type cithare_error =
   | CithareAlreadyConfigured
   | CithareNotConfigured
@@ -36,6 +41,7 @@ type cithare_warning =
   | NoMatchingPassword
   | TooManyMatchingPasswords of string list
   | CannotSaveState of string
+  | PasswordAlreadyExist
 
 exception CithareError of cithare_error
 
@@ -48,6 +54,8 @@ module Repr = struct
         @@ String.concat "\n\t- " website
     | CannotSaveState p ->
         Printf.sprintf "Can’t save state at %s" p
+    | PasswordAlreadyExist ->
+        "The given password already match an existing password"
 
   let string_of_options array =
     String.concat ", " @@ List.map (Printf.sprintf "-%s") @@ Array.to_list array
@@ -122,16 +130,22 @@ let missing_expecting_when_present missing when_set =
 
 let decryption_error = CithareError DecryptionError
 
-let emit_warning e =
-  Printf.printf "%s : %s\n"
-    (Cbindings.Termove.sprintf Cbindings.Termove.fg_magenta "warning")
-    (Repr.string_of_warning e)
+let emit_warning ?exit e =
+  let () =
+    Printf.printf "%s : %s\n"
+      (Cbindings.Termove.sprintf Cbindings.Termove.fg_magenta "warning")
+      (Repr.string_of_warning e)
+  in
+  match exit with None -> () | Some n -> Stdlib.exit n
 
-let emit_no_matching_password () = emit_warning NoMatchingPassword
+let emit_no_matching_password ?exit () = emit_warning ?exit NoMatchingPassword
 let emit_cannot_save_state path = emit_warning @@ CannotSaveState path
 
-let emit_too_many_matching_password list =
-  emit_warning @@ TooManyMatchingPasswords list
+let emit_too_many_matching_password ?exit list =
+  emit_warning ?exit @@ TooManyMatchingPasswords list
+
+let emit_already_existing_password ?exit () =
+  emit_warning ?exit PasswordAlreadyExist
 
 let register_cithare_error () =
   Printexc.register_printer (function

--- a/lib/libcithare/input.ml
+++ b/lib/libcithare/input.ml
@@ -24,8 +24,13 @@ module Prompt = struct
   let password_satifying = "Is password satisfying ? [y/n]"
   let wrong_choice = "Wrong Input!\nSelect between [y/n]"
   let empty_choice = "No Input!\nPlease select a reponse"
-  let try_again = "Do you want to try again? [y/n]"
-  let delete_password = "Do you want to delete all your password? [y/N]"
+  let try_again = "Do you want to try again ? [y/n]"
+  let delete_password = "Do you want to delete all your password? [y/n]"
+
+  let delete_password_list s =
+    Printf.sprintf "Do you want to delete the following passwords ? [y/n]\n%s"
+    @@ String.concat "\n"
+    @@ List.map (Printf.sprintf "  - %s") s
 end
 
 (**

--- a/lib/libcithare/manager.ml
+++ b/lib/libcithare/manager.ml
@@ -264,12 +264,8 @@ let password_match ~regex ?mail ?username website (password : Password.t) =
   - If all the elements are matched, manager is unchanged (the result of the function is then physically equal to [manager])
 *)
 let matches ?(negate = false) ?mail ?username ~regex website manager =
-  let f =
-    if negate then
-      Fun.negate (password_match ~regex ?mail ?username website)
-    else
-      password_match ~regex ?mail ?username website
-  in
+  let transformer = if negate then Fun.negate else Fun.id in
+  let f = transformer @@ password_match ~regex ?mail ?username website in
   let passwords_set = Passwords.filter f manager.passwords_set in
   if manager.passwords_set == passwords_set then
     manager

--- a/lib/util/misc.ml
+++ b/lib/util/misc.ml
@@ -15,7 +15,7 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-module FileSys = FileSys
-module Io = Io
-module Ustring = Ustring
-module Misc = Misc
+let rec compares compare lhs rhs = match compare with
+  | [] -> Stdlib.compare lhs rhs
+  | cmp::[] -> cmp lhs rhs
+  | cmp :: q -> match cmp lhs rhs with 0 -> compares q lhs rhs | n -> n

--- a/lib/util/misc.ml
+++ b/lib/util/misc.ml
@@ -15,7 +15,12 @@
 (*                                                                                            *)
 (**********************************************************************************************)
 
-let rec compares compare lhs rhs = match compare with
-  | [] -> Stdlib.compare lhs rhs
-  | cmp::[] -> cmp lhs rhs
-  | cmp :: q -> match cmp lhs rhs with 0 -> compares q lhs rhs | n -> n
+let rec compares compare lhs rhs =
+  match compare with
+  | [] ->
+      Stdlib.compare lhs rhs
+  | cmp :: [] ->
+      cmp lhs rhs
+  | cmp :: q -> (
+      match cmp lhs rhs with 0 -> compares q lhs rhs | n -> n
+    )

--- a/lib/util/ustring.ml
+++ b/lib/util/ustring.ml
@@ -26,3 +26,11 @@ let line ~first ~last length s =
     | _ ->
         s
     )
+
+let truncate n s =
+  let length = String.length s in
+  if length < n then
+    s
+  else
+    let subs = String.sub s 0 n in
+    Printf.sprintf "%s..." subs

--- a/misc/completions/cithare.fish
+++ b/misc/completions/cithare.fish
@@ -29,11 +29,16 @@ complete -c cithare -n "__fish_seen_subcommand_from generate-password or __fish_
 # cithare delete
 complete -c cithare -n "__fish_seen_subcommand_from delete" -f -r -s w -l website -d "Delete passwords matching <website>"
 complete -c cithare -n "__fish_seen_subcommand_from delete" -f -r -s a -l all -d "Delete all passwords"
+complete -c cithare -n "__fish_seen_subcommand_from delete" -f -r -s n -l username -d "Delete password by also matching <name>"
+complete -c cithare -n "__fish_seen_subcommand_from delete" -f -r -s m -l mail -d "Delete password by also matching <mail>"
 
 # cithare export
 complete -c cithare -n "__fish_seen_subcommand_from export" -r -s o -d "Export passwords as json"
-complete -c cithare -n "__fish_seen_subcommand_from export" -f -s r -l regex -d "Find the website by matching its name"
-complete -c cithare -n "__fish_seen_subcommand_from export" -f -r -s w -l website -d "Specify the site"
+complete -c cithare -n "__fish_seen_subcommand_from export" -f -s r -l regex -d "Treat each field as a regex string"
+complete -c cithare -n "__fish_seen_subcommand_from export" -f -r -s w -l website -d "Match the site"
+complete -c cithare -n "__fish_seen_subcommand_from export" -f -r -s m -l mail -d "Match the mail"
+complete -c cithare -n "__fish_seen_subcommand_from export" -f -r -s n -l username -d "Match the username"
+
 
 switch (uname)
 case Darwin


### PR DESCRIPTION
## Done 
- represent passwords as a set:
  - Keep the old representation for the serialization
- Add option to cithare-add and cithare-export to narrow the matching
- Fix save state: 
   - Before, it doesn't even checked the env variable content
 