### PR TITLE
Fix - Password replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unrealeased]
+- [cithare-add: Fix replace option by merging information with the old password record](https://github.com/EruEri/ocithare/pull/9)
+
 ## [0.11.0-1]
 - [Fix opam build dependancies](https://github.com/EruEri/ocithare/pull/8)
 

--- a/lib/commandline/cadd.ml
+++ b/lib/commandline/cadd.ml
@@ -79,37 +79,7 @@ let cmd run =
   let info = Cmd.info ~doc ~man name in
   Cmd.v info @@ term_cmd run
 
-let getpassword gen_password =
-  let CgenPassword.{ number; uppercase; lowercase; symbole; exclude; count } =
-    gen_password
-  in
-  match
-    (not (CgenPassword.CharSet.is_empty exclude))
-    || Option.is_some count
-    || Libcithare.Password.Generate.has_options ~number ~uppercase ~lowercase
-         ~symbole
-  with
-  | true ->
-      let count = Option.value ~default:CgenPassword.default_count count in
-      CgenPassword.is_password_satifying ~exclude ~number ~uppercase ~lowercase
-        ~symbole count
-  | false ->
-      let first =
-        Libcithare.Input.ask_password
-          ~prompt:Libcithare.Input.Prompt.new_password ()
-      in
-      let confirm =
-        Libcithare.Input.ask_password
-          ~prompt:Libcithare.Input.Prompt.confirm_password ()
-      in
-      let () =
-        match first = confirm with
-        | true ->
-            ()
-        | false ->
-            raise @@ Libcithare.Error.unmatched_password
-      in
-      Some first
+let getpassword = Common.getpassword
 
 let validate t =
   let () = Libcithare.Manager.check_initialized () in
@@ -119,13 +89,6 @@ let validate t =
     | None, None when not replace ->
         raise @@ Libcithare.Error.option_simult_none [| "-username"; "-mail" |]
     | _ ->
-        ()
-  in
-  let () =
-    match Util.FileSys.file_exists Libcithare.Config.cithare_password_file with
-    | false ->
-        raise @@ Libcithare.Error.cithare_not_configured
-    | true ->
         ()
   in
   ()

--- a/lib/commandline/cinit.ml
+++ b/lib/commandline/cinit.ml
@@ -127,7 +127,11 @@ let run t =
   in
   let () = Libcithare.Manager.encrypt ~encrypt_key:true pass manager in
   let extension =
-    match Option.is_some import with true -> "with passwords" | false -> String.empty
+    match Option.is_some import with
+    | true ->
+        "with passwords"
+    | false ->
+        String.empty
   in
   let () =
     Printf.printf "%s initiliazed %s\n%!" Libcithare.Config.cithare_name

--- a/lib/commandline/common.ml
+++ b/lib/commandline/common.ml
@@ -1,0 +1,48 @@
+(**********************************************************************************************)
+(*                                                                                            *)
+(* This file is part of ocithare: a commandline password manager                              *)
+(* Copyright (C) 2024 Yves Ndiaye                                                             *)
+(*                                                                                            *)
+(* ocithare is free software: you can redistribute it and/or modify it under the terms        *)
+(* of the GNU General Public License as published by the Free Software Foundation,            *)
+(* either version 3 of the License, or (at your option) any later version.                    *)
+(*                                                                                            *)
+(* ocithare is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;      *)
+(* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR           *)
+(* PURPOSE.  See the GNU General Public License for more details.                             *)
+(* You should have received a copy of the GNU General Public License along with ocithare.     *)
+(* If not, see <http://www.gnu.org/licenses/>.                                                *)
+(*                                                                                            *)
+(**********************************************************************************************)
+
+let getpassword gen_password =
+  let CgenPassword.{ number; uppercase; lowercase; symbole; exclude; count } =
+    gen_password
+  in
+  match
+    (not (CgenPassword.CharSet.is_empty exclude))
+    || Option.is_some count
+    || Libcithare.Password.Generate.has_options ~number ~uppercase ~lowercase
+         ~symbole
+  with
+  | true ->
+      let count = Option.value ~default:CgenPassword.default_count count in
+      CgenPassword.is_password_satifying ~exclude ~number ~uppercase ~lowercase
+        ~symbole count
+  | false ->
+      let first =
+        Libcithare.Input.ask_password
+          ~prompt:Libcithare.Input.Prompt.new_password ()
+      in
+      let confirm =
+        Libcithare.Input.ask_password
+          ~prompt:Libcithare.Input.Prompt.confirm_password ()
+      in
+      let () =
+        match first = confirm with
+        | true ->
+            ()
+        | false ->
+            raise @@ Libcithare.Error.unmatched_password
+      in
+      Some first

--- a/lib/libcithare/password.ml
+++ b/lib/libcithare/password.ml
@@ -126,5 +126,13 @@ let username { username; _ } = username
 let password { password; _ } = password
 let mail { mail; _ } = mail
 
+let merge fmail fusername old recent =
+  if old.website <> recent.website || old = recent then
+    old
+  else
+    let mail = fmail old.mail recent.mail in
+    let username = fusername old.username recent.username in
+    { recent with mail; username }
+
 let hide password =
   { password with password = String.map (fun _ -> '*') password.password }


### PR DESCRIPTION
## Done

- cithare-add: replace option
  - **Before**: Replace password (Password.t) without keeping information about the old one (take information from the args option)
  - **Now**   : Merge mail and username with the old one